### PR TITLE
V15 fix oom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@7rulnik/react-element-to-jsx-string",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "description": "Turn a ReactElement into the corresponding JSX string.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-element-to-jsx-string",
+  "name": "@7rulnik/react-element-to-jsx-string",
   "version": "15.0.0",
   "description": "Turn a ReactElement into the corresponding JSX string.",
   "main": "dist/cjs/index.js",
@@ -29,12 +29,9 @@
       "git add"
     ]
   },
-  "author": {
-    "name": "Algolia, Inc.",
-    "url": "https://github.com/algolia"
-  },
+  "author": "Valentin 7rulnik Semirulnik <v7rulnik@gmail.com>",
   "license": "MIT",
-  "repository": "algolia/react-element-to-jsx-string",
+  "repository": "7rulnik/react-element-to-jsx-string",
   "devDependencies": {
     "@babel/cli": "7.17.6",
     "@babel/core": "7.17.9",

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -7,12 +7,8 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
     return value;
   }
 
-  // return date, regexp and react element values as is
-  if (
-    value instanceof Date ||
-    value instanceof RegExp ||
-    React.isValidElement(value)
-  ) {
+  // return date and regexp values as is
+  if (value instanceof Date || value instanceof RegExp) {
     return value;
   }
 

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -12,6 +12,13 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
     return value;
   }
 
+  // return react element as is but remove _owner key because it can lead to recursion
+  if (React.isValidElement(value)) {
+    const copyObj = { ...value };
+    delete copyObj._owner;
+    return copyObj;
+  }
+
   seen.add(value);
 
   // make a copy of array with each item passed through the sorting algorithm
@@ -23,9 +30,6 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
   return Object.keys(value)
     .sort()
     .reduce((result, key) => {
-      if (key === '_owner') {
-        return result;
-      }
       if (key === 'current' || seen.has(value[key])) {
         // eslint-disable-next-line no-param-reassign
         result[key] = '[Circular]';

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import React from 'react';
 import sortObject from './sortObject';
 
 describe('sortObject', () => {
@@ -41,5 +42,25 @@ describe('sortObject', () => {
       b: regexp,
       c: date,
     });
+  });
+
+  it('should remove _owner key from react elements', () => {
+    const fixture = {
+      _owner: "_owner that doesn't belong to react element",
+      component: <div />,
+    };
+
+    expect(JSON.stringify(sortObject(fixture))).toEqual(
+      JSON.stringify({
+        _owner: "_owner that doesn't belong to react element",
+        component: {
+          $$typeof: Symbol('react.transitional.element'),
+          type: 'div',
+          key: null,
+          props: {},
+          _store: {},
+        },
+      })
+    );
   });
 });


### PR DESCRIPTION
So this PR published as [@7rulnik/react-element-to-jsx-string@15.0.1](https://www.npmjs.com/package/@7rulnik/react-element-to-jsx-string?activeTab=readme).

Branch v15 points to v15.0.0 tag. So this fix published on top of it and doesn't support react 19

https://github.com/algolia/react-element-to-jsx-string/pull/883

For v17 and react 19 support see https://github.com/7rulnik/react-element-to-jsx-string/pull/3